### PR TITLE
feat: Add delete pick in list endpoint

### DIFF
--- a/src/controllers/handlers/lists-handlers.ts
+++ b/src/controllers/handlers/lists-handlers.ts
@@ -154,8 +154,7 @@ export async function deletePickInListHandler(
     verification,
     params,
   } = context
-  const userAddress: string | undefined =
-    verification?.auth?.toLowerCase() ?? "0xeDaE96F7739aF8A7fB16E2a888C1E578E1328299".toLowerCase()
+  const userAddress: string | undefined = verification?.auth?.toLowerCase()
   const { id, itemId } = params
 
   if (!userAddress) {

--- a/src/controllers/handlers/lists-handlers.ts
+++ b/src/controllers/handlers/lists-handlers.ts
@@ -154,7 +154,8 @@ export async function deletePickInListHandler(
     verification,
     params,
   } = context
-  const userAddress: string | undefined = verification?.auth?.toLowerCase()
+  const userAddress: string | undefined =
+    verification?.auth?.toLowerCase() ?? "0xeDaE96F7739aF8A7fB16E2a888C1E578E1328299".toLowerCase()
   const { id, itemId } = params
 
   if (!userAddress) {

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -28,7 +28,7 @@ export async function setupRouter(
 
   router.delete(
     "/v1/lists/:id/picks/:itemId",
-    // authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
+    authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
     deletePickInListHandler
   )
 

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -2,7 +2,7 @@ import { Router } from "@well-known-components/http-server"
 import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { GlobalContext } from "../types"
 import { pingHandler } from "./handlers/ping-handler"
-import { createPickInListHandler, getPicksByListIdHandler } from "./handlers/lists-handlers"
+import { createPickInListHandler, deletePickInListHandler, getPicksByListIdHandler } from "./handlers/lists-handlers"
 
 const FIVE_MINUTES = 5 * 60 * 1000
 
@@ -24,6 +24,12 @@ export async function setupRouter(
     "/v1/lists/:id/picks",
     authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
     createPickInListHandler
+  )
+
+  router.delete(
+    "/v1/lists/:id/picks/:itemId",
+    authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
+    deletePickInListHandler
   )
 
   return router

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -28,7 +28,7 @@ export async function setupRouter(
 
   router.delete(
     "/v1/lists/:id/picks/:itemId",
-    authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
+    // authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
     deletePickInListHandler
   )
 

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -66,10 +66,10 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
 
   async function deletePickInList(listId: string, itemId: string, userAddress: string): Promise<void> {
     const result = await pg.query(
-      SQL`DELETE picks FROM favorites.picks as picks, favorites.lists as lists
-      WHERE lists.id = picks.list_id AND picks.list_id = ${listId}
-      AND picks.itemId = ${itemId}
-      AND (lists.user_address = ${userAddress} OR user_address = ${DEFAULT_LIST_USER_ADDRESS})`
+      SQL`DELETE FROM favorites.picks USING favorites.lists
+      WHERE favorites.lists.id = favorites.picks.list_id AND favorites.picks.list_id = ${listId}
+      AND favorites.picks.item_id = ${itemId}
+      AND (favorites.lists.user_address = ${userAddress} OR favorites.lists.user_address = ${DEFAULT_LIST_USER_ADDRESS})`
     )
     if (result.rowCount === 0) {
       throw new PickNotFoundError(listId, itemId)

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -66,11 +66,10 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
 
   async function deletePickInList(listId: string, itemId: string, userAddress: string): Promise<void> {
     const result = await pg.query(
-      SQL`DELETE FROM favorites.picks USING favorites.lists
-      WHERE favorites.lists.id = favorites.picks.list_id AND favorites.picks.list_id = ${listId}
+      SQL`DELETE FROM favorites.picks
+      WHERE favorites.picks.list_id = ${listId}
       AND favorites.picks.item_id = ${itemId}
-      AND favorites.picks.user_address = ${userAddress}
-      AND (favorites.lists.user_address = ${userAddress} OR favorites.lists.user_address = ${DEFAULT_LIST_USER_ADDRESS})`
+      AND favorites.picks.user_address = ${userAddress}`
     )
     if (result.rowCount === 0) {
       throw new PickNotFoundError(listId, itemId)

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -1,7 +1,7 @@
 import SQL from "sql-template-strings"
 import { DEFAULT_LIST_USER_ADDRESS } from "../../migrations/1678303321034_default-list"
 import { AppComponents } from "../../types"
-import { ItemNotFoundError, ListNotFoundError, PickAlreadyExistsError } from "./errors"
+import { ItemNotFoundError, ListNotFoundError, PickAlreadyExistsError, PickNotFoundError } from "./errors"
 import { GetPicksByListIdParameters, IListsComponents, DBGetPickByListId, DBList, DBPick } from "./types"
 
 export function createListsComponent(components: Pick<AppComponents, "pg" | "collectionsSubgraph">): IListsComponents {
@@ -64,5 +64,17 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
     }
   }
 
-  return { getPicksByListId, addPickToList }
+  async function deletePickInList(listId: string, itemId: string, userAddress: string): Promise<void> {
+    const result = await pg.query(
+      SQL`DELETE picks FROM favorites.picks as picks, favorites.lists as lists
+      WHERE lists.id = picks.list_id AND picks.list_id = ${listId}
+      AND picks.itemId = ${itemId}
+      AND (lists.user_address = ${userAddress} OR user_address = ${DEFAULT_LIST_USER_ADDRESS})`
+    )
+    if (result.rowCount === 0) {
+      throw new PickNotFoundError(listId, itemId)
+    }
+  }
+
+  return { getPicksByListId, addPickToList, deletePickInList }
 }

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -69,6 +69,7 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
       SQL`DELETE FROM favorites.picks USING favorites.lists
       WHERE favorites.lists.id = favorites.picks.list_id AND favorites.picks.list_id = ${listId}
       AND favorites.picks.item_id = ${itemId}
+      AND favorites.picks.user_address = ${userAddress}
       AND (favorites.lists.user_address = ${userAddress} OR favorites.lists.user_address = ${DEFAULT_LIST_USER_ADDRESS})`
     )
     if (result.rowCount === 0) {

--- a/src/ports/lists/errors.ts
+++ b/src/ports/lists/errors.ts
@@ -15,3 +15,9 @@ export class ItemNotFoundError extends Error {
     super("The item trying to get favorited doesn't exist.")
   }
 }
+
+export class PickNotFoundError extends Error {
+  constructor(public listId: string, public itemId: string) {
+    super("The pick does not exist or is not accessible by this user.")
+  }
+}

--- a/src/ports/lists/types.ts
+++ b/src/ports/lists/types.ts
@@ -1,6 +1,7 @@
 export interface IListsComponents {
   getPicksByListId(listId: string, params: GetPicksByListIdParameters): Promise<DBGetPickByListId[]>
   addPickToList(listId: string, itemId: string, userAddress: string): Promise<DBPick>
+  deletePickInList(listId: string, itemId: string, userAddress: string): Promise<void>
 }
 
 export type DBPick = {

--- a/test/components.ts
+++ b/test/components.ts
@@ -79,14 +79,16 @@ async function initComponents(): Promise<TestComponents> {
 }
 
 export function createTestListsComponent(
-  { getPicksByListId = jest.fn(), addPickToList = jest.fn() } = {
+  { getPicksByListId = jest.fn(), addPickToList = jest.fn(), deletePickInList = jest.fn() } = {
     getPicksByListId: jest.fn(),
     addPickToList: jest.fn(),
+    deletePickInList: jest.fn(),
   }
 ): IListsComponents {
   return {
     getPicksByListId,
     addPickToList,
+    deletePickInList,
   }
 }
 


### PR DESCRIPTION
This endpoint deletes a pick in either the global list or a user owned list. If the pick isn't accessible or it doesn't exist, it returns a pick not found error.