### PR TITLE
fix: Rewrite request types to include the verification

### DIFF
--- a/src/controllers/handlers/lists-handlers.ts
+++ b/src/controllers/handlers/lists-handlers.ts
@@ -1,4 +1,3 @@
-import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { fromDBGetPickByListIdToPickIdsWithCount, fromDBPickToPick } from "../../adapters/lists"
 import { TPick } from "../../adapters/lists/types"
 import { getPaginationParams } from "../../logic/http"
@@ -11,8 +10,10 @@ import {
 import { HandlerContextWithPath, HTTPResponse, StatusCode } from "../../types"
 
 export async function getPicksByListIdHandler(
-  context: Pick<HandlerContextWithPath<"lists", "/v1/lists/:id/picks">, "url" | "components" | "params" | "request"> &
-    authorizationMiddleware.DecentralandSignatureContext
+  context: Pick<
+    HandlerContextWithPath<"lists", "/v1/lists/:id/picks">,
+    "url" | "components" | "params" | "request" | "verification"
+  >
 ): Promise<HTTPResponse<Pick<TPick, "itemId">>> {
   const {
     url,
@@ -20,7 +21,7 @@ export async function getPicksByListIdHandler(
     verification,
     params,
   } = context
-  const userAddress: string | undefined = verification?.auth?.toLowerCase()
+  const userAddress: string | undefined = verification?.auth.toLowerCase()
 
   if (!userAddress) {
     return {
@@ -52,8 +53,10 @@ export async function getPicksByListIdHandler(
 }
 
 export async function createPickInListHandler(
-  context: Pick<HandlerContextWithPath<"lists", "/v1/lists/:id/picks">, "components" | "params" | "request"> &
-    authorizationMiddleware.DecentralandSignatureContext
+  context: Pick<
+    HandlerContextWithPath<"lists", "/v1/lists/:id/picks">,
+    "components" | "params" | "request" | "verification"
+  >
 ): Promise<HTTPResponse<TPick>> {
   const {
     components: { lists },
@@ -61,7 +64,7 @@ export async function createPickInListHandler(
     params,
     request,
   } = context
-  const userAddress: string | undefined = verification?.auth?.toLowerCase()
+  const userAddress: string | undefined = verification?.auth.toLowerCase()
   let body: { itemId?: string }
 
   if (!userAddress) {
@@ -146,15 +149,17 @@ export async function createPickInListHandler(
 }
 
 export async function deletePickInListHandler(
-  context: Pick<HandlerContextWithPath<"lists", "/v1/lists/:id/picks/:itemId">, "components" | "params" | "request"> &
-    authorizationMiddleware.DecentralandSignatureContext
+  context: Pick<
+    HandlerContextWithPath<"lists", "/v1/lists/:id/picks/:itemId">,
+    "components" | "params" | "request" | "verification"
+  >
 ): Promise<HTTPResponse<undefined>> {
   const {
     components: { lists },
     verification,
     params,
   } = context
-  const userAddress: string | undefined = verification?.auth?.toLowerCase()
+  const userAddress: string | undefined = verification?.auth.toLowerCase()
   const { id, itemId } = params
 
   if (!userAddress) {

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -7,10 +7,8 @@ import { createPickInListHandler, deletePickInListHandler, getPicksByListIdHandl
 const FIVE_MINUTES = 5 * 60 * 1000
 
 // We return the entire router because it will be easier to test than a whole server
-export async function setupRouter(
-  _globalContext: GlobalContext
-): Promise<Router<GlobalContext & authorizationMiddleware.DecentralandSignatureContext>> {
-  const router = new Router<GlobalContext & authorizationMiddleware.DecentralandSignatureContext>()
+export async function setupRouter(_globalContext: GlobalContext): Promise<Router<GlobalContext>> {
+  const router = new Router<GlobalContext>()
 
   router.get("/ping", pingHandler)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { IFetchComponent } from "@well-known-components/http-server"
+import type * as authorizationMiddleware from "decentraland-crypto-middleware"
 import type {
   IConfigComponent,
   ILoggerComponent,
@@ -47,7 +48,8 @@ export type HandlerContextWithPath<
 > = IHttpServerComponent.PathAwareContext<
   IHttpServerComponent.DefaultContext<{
     components: Pick<AppComponents, ComponentNames>
-  }>,
+  }> &
+    authorizationMiddleware.DecentralandSignatureContext,
   Path
 >
 


### PR DESCRIPTION
This PR rewrites the `HandlerContextWithPath` type to include the verification, making the handlers' section clearer.