### PR TITLE
feat: Store users VP when favoriting an item

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -13,6 +13,7 @@ HTTP_SERVER_HOST=0.0.0.0
 # reset metrics at 00:00UTC
 WKC_METRICS_RESET_AT_NIGHT=false
 
+SNAPSHOT_URL=https://score.snapshot.org/
 COLLECTIONS_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet
 SUBGRAPH_COMPONENT_RETRIES=0
 PG_COMPONENT_PSQL_DATABASE=marketplace

--- a/src/adapters/lists/lists.ts
+++ b/src/adapters/lists/lists.ts
@@ -15,6 +15,6 @@ export function fromDBPickToPick(dbPick: DBPick): TPick {
     itemId: dbPick.item_id,
     userAddress: dbPick.user_address,
     listId: dbPick.list_id,
-    createdAt: dbPick.created_at.toString(),
+    createdAt: Number(dbPick.created_at),
   }
 }

--- a/src/adapters/lists/types.ts
+++ b/src/adapters/lists/types.ts
@@ -2,7 +2,7 @@ export type TPick = {
   itemId: string
   userAddress: string
   listId: string
-  createdAt: string
+  createdAt: number
 }
 
 export type PickIdsWithCount = { picks: Pick<TPick, "itemId">[]; count: number }

--- a/src/components.ts
+++ b/src/components.ts
@@ -11,6 +11,7 @@ import { createFetchComponent } from "./ports/fetch"
 import { AppComponents, GlobalContext } from "./types"
 import { metricDeclarations } from "./metrics"
 import { createListsComponent } from "./ports/lists/component"
+import { createSnapshotComponent } from "./ports/snapshot"
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -53,7 +54,8 @@ export async function initComponents(): Promise<AppComponents> {
   const statusChecks = await createStatusCheckComponent({ server, config })
   const fetch = await createFetchComponent({ tracer })
   const collectionsSubgraph = await createSubgraphComponent({ logs, config, fetch, metrics }, COLLECTIONS_SUBGRAPH_URL)
-  const lists = await createListsComponent({ pg, collectionsSubgraph })
+  const snapshot = await createSnapshotComponent({ fetch, config })
+  const lists = await createListsComponent({ pg, collectionsSubgraph, snapshot, logs })
 
   return {
     config,
@@ -65,5 +67,6 @@ export async function initComponents(): Promise<AppComponents> {
     metrics,
     pg,
     lists,
+    snapshot,
   }
 }

--- a/src/logic/errors.ts
+++ b/src/logic/errors.ts
@@ -1,0 +1,3 @@
+export function isErrorWithMessage(error: unknown): error is Error {
+  return error !== undefined && error !== null && typeof error === "object" && "message" in error
+}

--- a/src/migrations/1678834025941_wallet-vp.ts
+++ b/src/migrations/1678834025941_wallet-vp.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate"
+
+export const WALLET_VP = "voting"
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(WALLET_VP, {
+    user_address: { type: "text", notNull: true, primaryKey: true },
+    power: { type: "integer", notNull: true },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable(WALLET_VP)
+}

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -1,11 +1,15 @@
 import SQL from "sql-template-strings"
+import { isErrorWithMessage } from "../../logic/errors"
 import { DEFAULT_LIST_USER_ADDRESS } from "../../migrations/1678303321034_default-list"
 import { AppComponents } from "../../types"
-import { ItemNotFoundError, ListNotFoundError, PickAlreadyExistsError, PickNotFoundError } from "./errors"
+import { ItemNotFoundError, ListNotFoundError, PickAlreadyExistsError, PickNotFoundError, QueryFailure } from "./errors"
 import { GetPicksByListIdParameters, IListsComponents, DBGetPickByListId, DBList, DBPick } from "./types"
 
-export function createListsComponent(components: Pick<AppComponents, "pg" | "collectionsSubgraph">): IListsComponents {
-  const { pg, collectionsSubgraph } = components
+export function createListsComponent(
+  components: Pick<AppComponents, "pg" | "collectionsSubgraph" | "snapshot" | "logs">
+): IListsComponents {
+  const { pg, collectionsSubgraph, snapshot, logs } = components
+  const logger = logs.getLogger("Lists component")
 
   async function getPicksByListId(listId: string, params: GetPicksByListIdParameters): Promise<DBGetPickByListId[]> {
     const { userAddress, limit, offset } = params
@@ -31,26 +35,53 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
 
   async function addPickToList(listId: string, itemId: string, userAddress: string): Promise<DBPick> {
     const list = await getList(listId, userAddress)
-    const queryResult = await collectionsSubgraph.query<{ items: { id: string }[] }>(
-      `query items($itemId: String) {
+    const [queryResult, power] = await Promise.allSettled([
+      collectionsSubgraph.query<{ items: { id: string }[] }>(
+        `query items($itemId: String) {
         items(first: 1, where: { id: $itemId }) {
           id
         }
       }`,
-      { itemId }
-    )
+        { itemId }
+      ),
+      snapshot.getScore(userAddress),
+    ])
 
-    if (queryResult.items.length === 0) {
+    if (queryResult.status === "rejected") {
+      logger.error("Querying the collections subgraph failed.")
+      throw new QueryFailure(isErrorWithMessage(queryResult.reason) ? queryResult.reason.message : "Unknown")
+    }
+
+    let vpQuery = SQL`INSERT INTO favorites.voting (user_address, power) `
+
+    // If the snapshot query fails, try to set the VP to 0 without overwriting it if it already exists
+    if (power.status === "rejected") {
+      logger.error(`Querying snapshot failed: ${isErrorWithMessage(power.reason) ? power.reason.message : "Unknown"}`)
+      vpQuery.append(SQL`VALUES (${userAddress}, ${0}) ON CONFLICT (user_address) DO NOTHING`)
+    } else {
+      vpQuery.append(
+        SQL`VALUES (${userAddress}, ${power.value}) ON CONFLICT (user_address) DO UPDATE SET power = ${power.value}`
+      )
+    }
+
+    if (queryResult.value.items.length === 0) {
       throw new ItemNotFoundError(itemId)
     }
 
+    const client = await pg.getPool().connect()
     try {
-      const result = await pg.query<DBPick>(
-        SQL`INSERT INTO favorites.picks (item_id, user_address, list_id) VALUES (${itemId}, ${userAddress}, ${list.id}) RETURNING *`
-      )
+      await client.query("BEGIN")
+      const results = await Promise.all([
+        client.query<DBPick>(
+          SQL`INSERT INTO favorites.picks (item_id, user_address, list_id) VALUES (${itemId}, ${userAddress}, ${list.id}) RETURNING *`
+        ),
+        client.query(vpQuery),
+      ])
+      await client.query("COMMIT")
 
-      return result.rows[0]
+      return results[0].rows[0]
     } catch (error) {
+      await client.query("ROLLBACK")
       if (
         error &&
         typeof error === "object" &&
@@ -61,6 +92,8 @@ export function createListsComponent(components: Pick<AppComponents, "pg" | "col
       }
 
       throw new Error("The pick couldn't be created")
+    } finally {
+      await client.release()
     }
   }
 

--- a/src/ports/lists/errors.ts
+++ b/src/ports/lists/errors.ts
@@ -21,3 +21,9 @@ export class PickNotFoundError extends Error {
     super("The pick does not exist or is not accessible by this user.")
   }
 }
+
+export class QueryFailure extends Error {
+  constructor(message: string) {
+    super(`Querying the subgraph failed: ${message}`)
+  }
+}

--- a/src/ports/snapshot/component.ts
+++ b/src/ports/snapshot/component.ts
@@ -1,0 +1,42 @@
+import { isErrorWithMessage } from "../../logic/errors"
+import { AppComponents } from "../../types"
+import { strategies } from "./constants"
+import { ScoreError } from "./errors"
+import { ISnapshotComponent, ScoreRequest, ScoreResponse } from "./types"
+
+export async function createSnapshotComponent(
+  components: Pick<AppComponents, "fetch" | "config">
+): Promise<ISnapshotComponent> {
+  const { fetch, config } = components
+  const SNAPSHOT_URL = await config.requireString("SNAPSHOT_URL")
+
+  async function getScore(address: string): Promise<number> {
+    const data: ScoreRequest = {
+      jsonrpc: "2.0",
+      method: "get_vp",
+      params: {
+        network: "1",
+        address: address.toLowerCase(),
+        strategies,
+        space: "snapshot.dcl.eth",
+        delegation: false,
+      },
+    }
+
+    try {
+      const res = await fetch.fetch(SNAPSHOT_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(data),
+      })
+      const body: ScoreResponse = await res.json()
+      return (body?.result?.vp || 0) | 0
+    } catch (err) {
+      throw new ScoreError(isErrorWithMessage(err) ? err.message : "Unknown", address)
+    }
+  }
+
+  return { getScore }
+}

--- a/src/ports/snapshot/constants.ts
+++ b/src/ports/snapshot/constants.ts
@@ -1,0 +1,67 @@
+export const strategies = [
+  {
+    name: "multichain",
+    network: "1",
+    params: {
+      name: "multichain",
+      graphs: {
+        137: "https://api.thegraph.com/subgraphs/name/decentraland/blocks-matic-mainnet",
+      },
+      symbol: "MANA",
+      strategies: [
+        {
+          name: "erc20-balance-of",
+          params: {
+            address: "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+            decimals: 18,
+          },
+          network: "1",
+        },
+        {
+          name: "erc20-balance-of",
+          params: {
+            address: "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4",
+            decimals: 18,
+          },
+          network: "137",
+        },
+      ],
+    },
+  },
+  {
+    name: "erc20-balance-of",
+    network: "1",
+    params: {
+      symbol: "WMANA",
+      address: "0xfd09cf7cfffa9932e33668311c4777cb9db3c9be",
+      decimals: 18,
+    },
+  },
+  {
+    name: "erc721-with-multiplier",
+    network: "1",
+    params: {
+      symbol: "LAND",
+      address: "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",
+      multiplier: 2000,
+    },
+  },
+  {
+    name: "decentraland-estate-size",
+    network: "1",
+    params: {
+      symbol: "ESTATE",
+      address: "0x959e104e1a4db6317fa58f8295f586e1a978c297",
+      multiplier: 2000,
+    },
+  },
+  {
+    name: "erc721-with-multiplier",
+    network: "1",
+    params: {
+      symbol: "NAMES",
+      address: "0x2a187453064356c898cae034eaed119e1663acb8",
+      multiplier: 100,
+    },
+  },
+]

--- a/src/ports/snapshot/errors.ts
+++ b/src/ports/snapshot/errors.ts
@@ -1,0 +1,5 @@
+export class ScoreError extends Error {
+  constructor(message: string, public address: string) {
+    super(`Error loading user score: ${message}`)
+  }
+}

--- a/src/ports/snapshot/index.ts
+++ b/src/ports/snapshot/index.ts
@@ -1,0 +1,2 @@
+export * from "./component"
+export * from "./types"

--- a/src/ports/snapshot/types.ts
+++ b/src/ports/snapshot/types.ts
@@ -1,0 +1,25 @@
+export type ScoreRequest = {
+  jsonrpc: "2.0"
+  method: "get_vp"
+  params: {
+    address: string
+    network: "1"
+    strategies: any[]
+    snapshot?: number
+    space: string
+    delegation: boolean
+  }
+}
+
+export type ScoreResponse = {
+  jsonrpc: "2.0"
+  result: {
+    vp: number
+    vp_by_strategy: number
+    vp_state: string
+  }
+}
+
+export interface ISnapshotComponent {
+  getScore(address: string): Promise<number>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ import { ISubgraphComponent } from "@well-known-components/thegraph-component"
 import { PaginatedResponse } from "./logic/http"
 import { metricDeclarations } from "./metrics"
 import { IListsComponents } from "./ports/lists/types"
+import { ISnapshotComponent } from "./ports/snapshot"
 
 export type GlobalContext = {
   components: BaseComponents
@@ -28,6 +29,7 @@ export type BaseComponents = {
   pg: IPgComponent & IDatabase
   lists: IListsComponents
   collectionsSubgraph: ISubgraphComponent
+  snapshot: ISnapshotComponent
 }
 
 // components used in runtime

--- a/test/unit/lists-adapters.spec.ts
+++ b/test/unit/lists-adapters.spec.ts
@@ -59,7 +59,7 @@ describe("when transforming a DB retrieved pick to a pick", () => {
       itemId: dbPick.item_id,
       userAddress: dbPick.user_address,
       listId: dbPick.list_id,
-      createdAt: dbPick.created_at.toString(),
+      createdAt: Number(dbPick.created_at),
     })
   })
 })

--- a/test/unit/lists-handler.spec.ts
+++ b/test/unit/lists-handler.spec.ts
@@ -269,7 +269,7 @@ describe("when creating a pick", () => {
           data: {
             itemId,
             listId,
-            createdAt: pick.created_at.toString(),
+            createdAt: Number(pick.created_at),
             userAddress: verification!.auth!,
           },
         },

--- a/test/unit/snapshot-component.spec.ts
+++ b/test/unit/snapshot-component.spec.ts
@@ -1,0 +1,64 @@
+import { IFetchComponent } from "@well-known-components/http-server"
+import { IConfigComponent } from "@well-known-components/interfaces"
+import { createSnapshotComponent, ISnapshotComponent } from "../../src/ports/snapshot"
+import { ScoreError } from "../../src/ports/snapshot/errors"
+
+let snapshotComponent: ISnapshotComponent
+let fetchComponent: IFetchComponent
+let configComponent: IConfigComponent
+let mockedRequireString: jest.Mock
+let mockedFetch: jest.Mock
+
+beforeEach(async () => {
+  mockedRequireString = jest.fn()
+  mockedFetch = jest.fn()
+  fetchComponent = { fetch: mockedFetch }
+  configComponent = {
+    getString: jest.fn(),
+    getNumber: jest.fn(),
+    requireString: mockedRequireString,
+    requireNumber: jest.fn(),
+  }
+  snapshotComponent = await createSnapshotComponent({ config: configComponent, fetch: fetchComponent })
+})
+
+describe("when getting the user's score", () => {
+  const address = "0xa3D963609EEaA7aA796c81E8c6f945c601f9BEc7"
+  const snapshotURL = "http://snapshot-url.com"
+  beforeEach(() => {
+    mockedRequireString.mockResolvedValueOnce(snapshotURL)
+  })
+
+  describe("and the request to snapshot fails", () => {
+    beforeEach(() => {
+      mockedFetch.mockRejectedValueOnce(new Error("An error occurred"))
+    })
+
+    it("should throw a score error with the reason", () => {
+      return expect(snapshotComponent.getScore(address)).rejects.toEqual(new ScoreError("An error occurred", address))
+    })
+  })
+
+  describe("and the request to snapshot is successful", () => {
+    describe("and the response does not contain the voting power", () => {
+      beforeEach(() => {
+        mockedFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ result: {} }) })
+      })
+
+      it("should resolve the voting power as 0", () => {
+        return expect(snapshotComponent.getScore(address)).resolves.toEqual(0)
+      })
+    })
+
+    describe("and the response contains the voting power", () => {
+      const vp = 10
+      beforeEach(() => {
+        mockedFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ result: { vp } }) })
+      })
+
+      it("should resolve the voting power of the user", () => {
+        return expect(snapshotComponent.getScore(address)).resolves.toEqual(vp)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR changes the way we create favorites of an item by storing the voting power of the users. This procedure is now done in a transaction, to ensure that both the item and the voting power are inserted.
The voting power of the users is requested to the snapshot server. If the request fails, the voting power of the user is set to 0 (if there wasn't any VP present before) or is discarded if there was.