### PR TITLE
feat: Add the picks stats endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   coveragePathIgnorePatterns: ["/node_modules/", "index.ts", "src/migrations"],
   testMatch: ["**/*.spec.(ts)"],
   testEnvironment: "node",
+  resetMocks: true,
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -13,6 +13,7 @@ import { AppComponents, GlobalContext } from "./types"
 import { metricDeclarations } from "./metrics"
 import { createListsComponent } from "./ports/lists/component"
 import { createSnapshotComponent } from "./ports/snapshot"
+import { createPicksComponent } from "./ports/picks"
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -58,6 +59,7 @@ export async function initComponents(): Promise<AppComponents> {
   const collectionsSubgraph = await createSubgraphComponent({ logs, config, fetch, metrics }, COLLECTIONS_SUBGRAPH_URL)
   const snapshot = await createSnapshotComponent({ fetch, config })
   const lists = await createListsComponent({ pg, collectionsSubgraph, snapshot, logs })
+  const picks = createPicksComponent({ pg })
 
   return {
     config,
@@ -70,5 +72,6 @@ export async function initComponents(): Promise<AppComponents> {
     pg,
     lists,
     snapshot,
+    picks,
   }
 }

--- a/src/controllers/handlers/picks-handlers.ts
+++ b/src/controllers/handlers/picks-handlers.ts
@@ -1,0 +1,45 @@
+import { getNumberParameter } from "../../logic/http"
+import { InvalidParameterError } from "../../logic/http/errors"
+import { PickStats } from "../../ports/picks"
+import { HandlerContextWithPath, HTTPResponse, StatusCode } from "../../types"
+
+export async function getPickStatsHandler(
+  context: Pick<
+    HandlerContextWithPath<"picks", "/v1/picks/:itemId/stats">,
+    "url" | "components" | "params" | "request" | "verification"
+  >
+): Promise<HTTPResponse<PickStats>> {
+  const {
+    url,
+    components: { picks },
+    verification,
+    params,
+  } = context
+  const userAddress: string | undefined = verification?.auth.toLowerCase()
+
+  try {
+    const power = getNumberParameter("power", url.searchParams)
+
+    const pickStats = await picks.getPickStats(params.itemId, { userAddress, power: power ?? undefined })
+
+    return {
+      status: StatusCode.OK,
+      body: {
+        ok: true,
+        data: pickStats,
+      },
+    }
+  } catch (error) {
+    if (error instanceof InvalidParameterError) {
+      return {
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: error.message,
+        },
+      }
+    }
+
+    throw error
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -3,6 +3,7 @@ import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { GlobalContext } from "../types"
 import { pingHandler } from "./handlers/ping-handler"
 import { createPickInListHandler, deletePickInListHandler, getPicksByListIdHandler } from "./handlers/lists-handlers"
+import { getPickStatsHandler } from "./handlers/picks-handlers"
 
 const FIVE_MINUTES = 5 * 60 * 1000
 
@@ -28,6 +29,12 @@ export async function setupRouter(_globalContext: GlobalContext): Promise<Router
     "/v1/lists/:id/picks/:itemId",
     authorizationMiddleware.wellKnownComponents({ optional: false, expiration: FIVE_MINUTES }),
     deletePickInListHandler
+  )
+
+  router.get(
+    "/v1/picks/:itemId/stats",
+    authorizationMiddleware.wellKnownComponents({ optional: true, expiration: FIVE_MINUTES }),
+    getPickStatsHandler
   )
 
   return router

--- a/src/logic/http/errors.ts
+++ b/src/logic/http/errors.ts
@@ -1,0 +1,5 @@
+export class InvalidParameterError extends Error {
+  constructor(parameter: string, value: string) {
+    super(`The value of the ${parameter} parameter is invalid: ${value}`)
+  }
+}

--- a/src/logic/http/pagination.ts
+++ b/src/logic/http/pagination.ts
@@ -1,3 +1,5 @@
+import { InvalidParameterError } from "./errors"
+
 const MAX_LIMIT = 100
 const DEFAULT_PAGE = 0
 
@@ -19,4 +21,19 @@ export const getPaginationParams = (params: URLSearchParams): { limit: number; o
     limit: paginationLimit,
     offset: paginationOffset,
   }
+}
+
+export function getNumberParameter(parameterName: string, params: URLSearchParams): number | undefined {
+  const parameter = params.get(parameterName)
+
+  if (parameter === null) {
+    return undefined
+  }
+
+  const valueAsNumber = Number.parseInt(parameter)
+  if (Number.isNaN(valueAsNumber)) {
+    throw new InvalidParameterError(parameterName, parameter)
+  }
+
+  return valueAsNumber
 }

--- a/src/ports/picks/component.ts
+++ b/src/ports/picks/component.ts
@@ -1,0 +1,36 @@
+import SQL from "sql-template-strings"
+import { AppComponents } from "../../types"
+import { DEFAULT_VOTING_POWER } from "./constants"
+import { IPicksComponent, PickStats } from "./types"
+
+export function createPicksComponent(components: Pick<AppComponents, "pg">): IPicksComponent {
+  const { pg } = components
+
+  async function getPickStats(itemId: string, options?: { userAddress?: string; power?: number }): Promise<PickStats> {
+    const checkIfUserLikedTheItem = Boolean(options?.userAddress)
+    const query = SQL`SELECT COUNT(DISTINCT picks.user_address)`
+    if (checkIfUserLikedTheItem) {
+      query.append(", (hasLiked.counter > 0) likedByUser")
+    }
+    query.append("FROM favorites.picks picks, favorites.voting voting")
+    if (checkIfUserLikedTheItem) {
+      query.append(
+        SQL`, (SELECT COUNT(*) counter FROM favorites.picks WHERE favorites.picks.user_address = ${options?.userAddress} AND favorites.picks.item_id = ${itemId} LIMIT 1) hasLiked`
+      )
+    }
+    query.append(
+      SQL`WHERE picks.item_id = ${itemId} AND voting.user_address = picks.user_address AND voting.power >= ${
+        options?.power ?? DEFAULT_VOTING_POWER
+      }`
+    )
+    if (checkIfUserLikedTheItem) {
+      query.append(`GROUP BY (hasLiked.counter)`)
+    }
+
+    const result = await pg.query<PickStats>(query)
+
+    return result.rows[0]
+  }
+
+  return { getPickStats }
+}

--- a/src/ports/picks/component.ts
+++ b/src/ports/picks/component.ts
@@ -8,18 +8,18 @@ export function createPicksComponent(components: Pick<AppComponents, "pg">): IPi
 
   async function getPickStats(itemId: string, options?: { userAddress?: string; power?: number }): Promise<PickStats> {
     const checkIfUserLikedTheItem = Boolean(options?.userAddress)
-    const query = SQL`SELECT COUNT(DISTINCT picks.user_address)`
+    const query = SQL`SELECT COUNT(DISTINCT favorites.picks.user_address)`
     if (checkIfUserLikedTheItem) {
       query.append(", (hasLiked.counter > 0) likedByUser")
     }
-    query.append("FROM favorites.picks picks, favorites.voting voting")
+    query.append(" FROM favorites.picks, favorites.voting")
     if (checkIfUserLikedTheItem) {
       query.append(
         SQL`, (SELECT COUNT(*) counter FROM favorites.picks WHERE favorites.picks.user_address = ${options?.userAddress} AND favorites.picks.item_id = ${itemId} LIMIT 1) hasLiked`
       )
     }
     query.append(
-      SQL`WHERE picks.item_id = ${itemId} AND voting.user_address = picks.user_address AND voting.power >= ${
+      SQL` WHERE favorites.picks.item_id = ${itemId} AND favorites.voting.user_address = favorites.picks.user_address AND favorites.voting.power >= ${
         options?.power ?? DEFAULT_VOTING_POWER
       }`
     )

--- a/src/ports/picks/constants.ts
+++ b/src/ports/picks/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_VOTING_POWER = 1

--- a/src/ports/picks/index.ts
+++ b/src/ports/picks/index.ts
@@ -1,0 +1,2 @@
+export * from "./component"
+export * from "./types"

--- a/src/ports/picks/types.ts
+++ b/src/ports/picks/types.ts
@@ -1,0 +1,8 @@
+export interface IPicksComponent {
+  getPickStats(itemId: string, options?: { userAddress?: string; power?: number }): Promise<PickStats>
+}
+
+export type PickStats = {
+  likedByUser?: boolean
+  count: number
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import { PaginatedResponse } from "./logic/http"
 import { metricDeclarations } from "./metrics"
 import { IListsComponents } from "./ports/lists/types"
 import { ISnapshotComponent } from "./ports/snapshot"
+import { IPicksComponent } from "./ports/picks"
 
 export type GlobalContext = {
   components: BaseComponents
@@ -30,6 +31,7 @@ export type BaseComponents = {
   lists: IListsComponents
   collectionsSubgraph: ISubgraphComponent
   snapshot: ISnapshotComponent
+  picks: IPicksComponent
 }
 
 // components used in runtime

--- a/test/components.ts
+++ b/test/components.ts
@@ -14,6 +14,7 @@ import { createPgComponent, IPgComponent } from "@well-known-components/pg-compo
 import { createFetchComponent } from "../src/ports/fetch"
 import { createSnapshotComponent, ISnapshotComponent } from "../src/ports/snapshot"
 import { createListsComponent, IListsComponents } from "../src/ports/lists"
+import { createPicksComponent, IPicksComponent } from "../src/ports/picks"
 import { metricDeclarations } from "../src/metrics"
 import { main } from "../src/service"
 import { GlobalContext, TestComponents } from "../src/types"
@@ -68,6 +69,7 @@ async function initComponents(): Promise<TestComponents> {
   const collectionsSubgraph = await createSubgraphComponent({ logs, config, fetch, metrics }, "subgraph-url")
   const snapshot = await createSnapshotComponent({ fetch, config })
   const lists = await createListsComponent({ pg, collectionsSubgraph, snapshot, logs })
+  const picks = await createPicksComponent({ pg })
 
   return {
     config,
@@ -78,6 +80,7 @@ async function initComponents(): Promise<TestComponents> {
     server,
     fetch,
     lists,
+    picks,
     collectionsSubgraph,
     localFetch: await createLocalFetchCompoment(config),
   }
@@ -86,6 +89,12 @@ async function initComponents(): Promise<TestComponents> {
 export function createTestLogsComponent({ getLogger = jest.fn() } = { getLogger: jest.fn() }): ILoggerComponent {
   return {
     getLogger,
+  }
+}
+
+export function createTestPicksComponent({ getPickStats = jest.fn() } = { getPickStats: jest.fn() }): IPicksComponent {
+  return {
+    getPickStats,
   }
 }
 

--- a/test/unit/http-logic.spec.ts
+++ b/test/unit/http-logic.spec.ts
@@ -1,5 +1,6 @@
 import { URLSearchParams } from "url"
-import { getPaginationParams } from "../../src/logic/http"
+import { getNumberParameter, getPaginationParams } from "../../src/logic/http"
+import { InvalidParameterError } from "../../src/logic/http/errors"
 
 describe("when getting the pagination params", () => {
   describe("and the limit is greater than the max limit", () => {
@@ -71,6 +72,42 @@ describe("when getting the pagination params", () => {
         limit: 100,
         offset: 100,
       })
+    })
+  })
+})
+
+describe("getNumberParameter", () => {
+  let searchParams: URLSearchParams
+
+  describe("when the search parameter is not defined", () => {
+    beforeEach(() => {
+      searchParams = new URLSearchParams()
+    })
+
+    it("should return undefined when value is null", () => {
+      expect(getNumberParameter("parameterName", searchParams)).toBe(undefined)
+    })
+  })
+
+  describe("when the search parameter value is an integer", () => {
+    beforeEach(() => {
+      searchParams = new URLSearchParams({ parameterName: "12" })
+    })
+
+    it("should return parsed number", () => {
+      expect(getNumberParameter("parameterName", searchParams)).toBe(12)
+    })
+  })
+
+  describe("when the search parameter value is not a valid number", () => {
+    beforeEach(() => {
+      searchParams = new URLSearchParams({ parameterName: "test" })
+    })
+
+    it("should throw InvalidParameterError", () => {
+      expect(() => getNumberParameter("parameterName", searchParams)).toThrow(
+        new InvalidParameterError("parameterName", "test")
+      )
     })
   })
 })

--- a/test/unit/lists-component.spec.ts
+++ b/test/unit/lists-component.spec.ts
@@ -31,10 +31,6 @@ let collectionsSubgraph: ISubgraphComponent
 let snapshot: ISnapshotComponent
 let logs: ILoggerComponent
 
-afterEach(() => {
-  jest.resetAllMocks()
-})
-
 beforeEach(async () => {
   dbQueryMock = jest.fn()
   collectionsSubgraphQueryMock = jest.fn()

--- a/test/unit/picks-component.spec.ts
+++ b/test/unit/picks-component.spec.ts
@@ -1,0 +1,137 @@
+import { IDatabase } from "@well-known-components/interfaces"
+import { IPgComponent } from "@well-known-components/pg-component"
+import { createPicksComponent, IPicksComponent, PickStats } from "../../src/ports/picks"
+import { createTestPgComponent } from "../components"
+
+let options: {
+  userAddress?: string
+  power?: number
+}
+let itemId: string
+let dbQueryMock: jest.Mock
+let pg: IPgComponent & IDatabase
+let picksComponent: IPicksComponent
+
+beforeEach(() => {
+  dbQueryMock = jest.fn()
+  pg = createTestPgComponent({
+    query: dbQueryMock,
+  })
+  itemId = "0x08de0de733cc11081d43569b809c00e6ddf314fb-0"
+  options = {
+    userAddress: "0x1dec5f50cb1467f505bb3ddfd408805114406b10",
+    power: 2,
+  }
+  picksComponent = createPicksComponent({ pg })
+})
+
+describe("when getting the pick stats of an item", () => {
+  let result: PickStats | undefined
+  beforeEach(() => {
+    result = undefined
+  })
+
+  describe("and the power parameter is set", () => {
+    beforeEach(async () => {
+      options.power = 20
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ counts: 1000 }] })
+      result = await picksComponent.getPickStats(itemId, options)
+    })
+
+    it("should query the favorites that were done by users with power greater and equal than the given power", () => {
+      expect(dbQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(`voting.power >= `),
+          values: expect.arrayContaining([options.power]),
+        })
+      )
+    })
+
+    it("should return the amount of favorites", () => {
+      expect(result).toEqual({ counts: 1000 })
+    })
+  })
+
+  describe("and the power parameter is not set", () => {
+    beforeEach(async () => {
+      options.power = undefined
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ counts: 1000 }] })
+      result = await picksComponent.getPickStats(itemId, options)
+    })
+
+    it("should query the favorites that were done by users with power greater and equal than default power", () => {
+      expect(dbQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(`voting.power >= `),
+          values: expect.arrayContaining([1]),
+        })
+      )
+    })
+
+    it("should return the amount of favorites", () => {
+      expect(result).toEqual({ counts: 1000 })
+    })
+  })
+
+  describe("and the user address parameter is set", () => {
+    beforeEach(async () => {
+      options.userAddress = "aUserAddress"
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ counts: 1000, likedByUser: true }] })
+      result = await picksComponent.getPickStats(itemId, options)
+    })
+
+    it("should not check in the query if the user has liked the item", () => {
+      expect(dbQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(", (hasLiked.counter > 0) likedByUser"),
+        })
+      )
+      expect(dbQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("SELECT COUNT(*) counter FROM favorites.picks"),
+          values: expect.arrayContaining([options.userAddress, itemId]),
+        })
+      )
+      expect(dbQueryMock).toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("GROUP BY (hasLiked.counter)"),
+          values: expect.arrayContaining([options.userAddress, itemId]),
+        })
+      )
+    })
+
+    it("should return the amount of favorites and the liked by user property", () => {
+      expect(result).toEqual({ counts: 1000, likedByUser: true })
+    })
+  })
+
+  describe("and the user address parameter is not set", () => {
+    beforeEach(async () => {
+      options.userAddress = undefined
+      dbQueryMock.mockResolvedValueOnce({ rows: [{ counts: 1000 }] })
+      result = await picksComponent.getPickStats(itemId, options)
+    })
+
+    it("should check in the query if the user has liked the item", () => {
+      expect(dbQueryMock).not.toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining(", (hasLiked.counter > 0) likedByUser"),
+        })
+      )
+      expect(dbQueryMock).not.toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("SELECT COUNT(*) counter FROM favorites.picks"),
+        })
+      )
+      expect(dbQueryMock).not.toBeCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("GROUP BY (hasLiked.counter)"),
+        })
+      )
+    })
+
+    it("should return the amount of favorites", () => {
+      expect(result).toEqual({ counts: 1000 })
+    })
+  })
+})

--- a/test/unit/picks-component.spec.ts
+++ b/test/unit/picks-component.spec.ts
@@ -80,7 +80,7 @@ describe("when getting the pick stats of an item", () => {
       result = await picksComponent.getPickStats(itemId, options)
     })
 
-    it("should not check in the query if the user has liked the item", () => {
+    it("should check in the query if the user has liked the item", () => {
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
           text: expect.stringContaining(", (hasLiked.counter > 0) likedByUser"),
@@ -95,7 +95,6 @@ describe("when getting the pick stats of an item", () => {
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
           text: expect.stringContaining("GROUP BY (hasLiked.counter)"),
-          values: expect.arrayContaining([options.userAddress, itemId]),
         })
       )
     })
@@ -112,7 +111,7 @@ describe("when getting the pick stats of an item", () => {
       result = await picksComponent.getPickStats(itemId, options)
     })
 
-    it("should check in the query if the user has liked the item", () => {
+    it("should not check in the query if the user has liked the item", () => {
       expect(dbQueryMock).not.toBeCalledWith(
         expect.objectContaining({
           text: expect.stringContaining(", (hasLiked.counter > 0) likedByUser"),

--- a/test/unit/picks-handler.spec.ts
+++ b/test/unit/picks-handler.spec.ts
@@ -1,0 +1,123 @@
+import * as authorizationMiddleware from "decentraland-crypto-middleware"
+import { getPickStatsHandler } from "../../src/controllers/handlers/picks-handlers"
+import { PickStats } from "../../src/ports/picks"
+import { AppComponents, HandlerContextWithPath, StatusCode } from "../../src/types"
+import { createTestPicksComponent } from "../components"
+
+let url: URL
+let userAddress: string
+let verification: authorizationMiddleware.DecentralandSignatureData | undefined
+let components: Pick<AppComponents, "picks">
+let itemId: string
+let getPickStatsMock: jest.Mock
+
+beforeEach(() => {
+  userAddress = "0x58ae4c4cb2b35632ea98f214a2918b171f1e1247"
+  verification = { auth: userAddress, authMetadata: {} }
+  itemId = "list-id"
+})
+
+beforeEach(() => {
+  getPickStatsMock = jest.fn()
+  components = {
+    picks: createTestPicksComponent({ getPickStats: getPickStatsMock }),
+  }
+})
+
+describe("when getting the stats of a pick", () => {
+  let request: HandlerContextWithPath<"picks", "/v1/picks/:itemId/stats">["request"]
+  let params: HandlerContextWithPath<"picks", "/v1/picks/:itemId/stats">["params"]
+
+  beforeEach(() => {
+    request = {} as HandlerContextWithPath<"picks", "/v1/picks/:itemId/stats">["request"]
+    params = { itemId }
+    url = new URL(`http://localhost/v1/picks/${itemId}/stats`)
+  })
+
+  describe("and the power parameter is set and it's not a number", () => {
+    beforeEach(() => {
+      url = new URL(`http://localhost/v1/picks/${itemId}/stats?power=anInvalidValue`)
+    })
+
+    it("should return a bad request response", () => {
+      return expect(getPickStatsHandler({ params, components, url, request, verification })).resolves.toEqual({
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: `The value of the power parameter is invalid: anInvalidValue`,
+        },
+      })
+    })
+  })
+
+  describe("and the power parameter is set as a number", () => {
+    beforeEach(() => {
+      url = new URL(`http://localhost/v1/picks/${itemId}/stats?power=200`)
+    })
+
+    it("should request the stats using the power parameter", async () => {
+      await getPickStatsHandler({ params, components, url, request, verification })
+      expect(getPickStatsMock).toHaveBeenCalledWith(itemId, expect.objectContaining({ power: 200 }))
+    })
+  })
+
+  describe("and the power parameter is not set", () => {
+    beforeEach(() => {
+      url = new URL(`http://localhost/v1/picks/${itemId}/stats`)
+    })
+
+    it("should request the stats without the power parameter", async () => {
+      await getPickStatsHandler({ params, components, url, request, verification })
+      expect(getPickStatsMock).toHaveBeenCalledWith(itemId, expect.objectContaining({ power: undefined }))
+    })
+  })
+
+  describe("and the request is authenticated with a signature", () => {
+    it("should request the stats using the user address of the authenticated user", async () => {
+      await getPickStatsHandler({ params, components, url, request, verification })
+      expect(getPickStatsMock).toHaveBeenCalledWith(itemId, expect.objectContaining({ userAddress }))
+    })
+  })
+
+  describe("and the request is not authenticated with a signature", () => {
+    it("should request the stats without a user address", async () => {
+      await getPickStatsHandler({ params, components, url, request, verification: undefined })
+      expect(getPickStatsMock).toHaveBeenCalledWith(itemId, expect.objectContaining({ userAddress: undefined }))
+    })
+  })
+
+  describe("and getting the pick stats fails", () => {
+    let error: Error
+
+    beforeEach(() => {
+      error = new Error("anError")
+      getPickStatsMock.mockRejectedValueOnce(error)
+    })
+
+    it("should propagate the error", () => {
+      return expect(getPickStatsHandler({ params, components, url, request, verification })).rejects.toEqual(error)
+    })
+  })
+
+  describe("and the request is successful", () => {
+    let pickStats: PickStats
+
+    beforeEach(() => {
+      pickStats = {
+        likedByUser: true,
+        count: 1000,
+      }
+      getPickStatsMock.mockResolvedValueOnce(pickStats)
+    })
+
+    it("should return an ok response with the stats", () => {
+      return expect(getPickStatsHandler({ params, components, url, request, verification })).resolves.toEqual({
+        status: StatusCode.OK,
+        body: {
+          ok: true,
+          data: pickStats,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the picks stats endpoint. This endpoint retrieves the amount of favorites an item has and if the user favorited or not the item.

Closes #14 