### PR TITLE
fix: Pick by user not being included when false

### DIFF
--- a/src/adapters/picks/picks.ts
+++ b/src/adapters/picks/picks.ts
@@ -22,7 +22,7 @@ export function fromDBPickStatsToPickStats(dbPickStat: DBPickStats): PickStats {
     count: Number(dbPickStat.count)
   }
 
-  if (dbPickStat.picked_by_user) {
+  if (dbPickStat.picked_by_user !== undefined) {
     stats.pickedByUser = dbPickStat.picked_by_user
   }
 

--- a/test/unit/picks-adapters.spec.ts
+++ b/test/unit/picks-adapters.spec.ts
@@ -59,15 +59,31 @@ describe('when transforming DB retrieved pick stats into pick stats', () => {
   })
 
   describe('and the DB pick stats have the picked_by_user property', () => {
-    beforeEach(() => {
-      dbPickStats.picked_by_user = true
+    describe('and its false', () => {
+      beforeEach(() => {
+        dbPickStats.picked_by_user = false
+      })
+
+      it('should convert the DB pick stats into pick stats with the pickedByUser property', () => {
+        expect(fromDBPickStatsToPickStats(dbPickStats)).toStrictEqual({
+          itemId: dbPickStats.item_id,
+          count: Number(dbPickStats.count),
+          pickedByUser: dbPickStats.picked_by_user
+        })
+      })
     })
 
-    it('should convert the DB pick stats into pick stats with the pickedByUser property', () => {
-      expect(fromDBPickStatsToPickStats(dbPickStats)).toStrictEqual({
-        itemId: dbPickStats.item_id,
-        count: Number(dbPickStats.count),
-        pickedByUser: dbPickStats.picked_by_user
+    describe('and its true', () => {
+      beforeEach(() => {
+        dbPickStats.picked_by_user = true
+      })
+
+      it('should convert the DB pick stats into pick stats with the pickedByUser property', () => {
+        expect(fromDBPickStatsToPickStats(dbPickStats)).toStrictEqual({
+          itemId: dbPickStats.item_id,
+          count: Number(dbPickStats.count),
+          pickedByUser: dbPickStats.picked_by_user
+        })
       })
     })
   })


### PR DESCRIPTION
This PR fixes an small issue that occurred when the `picked_by_user` property was false. The expected behavior was to always include the `pickedByUser` property if the `picked_by_user` property was defined but that wasn't the case when it was false.