### PR TITLE
feat: Use VP from Goerli and Mumbai

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -17,6 +17,8 @@ CORS_METHODS=*
 WKC_METRICS_RESET_AT_NIGHT=false
 
 SNAPSHOT_URL=https://score.snapshot.org/
+SNAPSHOT_NETWORK=1
+SNAPSHOT_SPACE=snapshot.dcl.eth
 COLLECTIONS_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet
 SUBGRAPH_COMPONENT_RETRIES=0
 PG_COMPONENT_PSQL_DATABASE=marketplace

--- a/src/ports/snapshot/component.ts
+++ b/src/ports/snapshot/component.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@dcl/schemas'
 import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
 import { strategies } from './constants'
@@ -7,16 +8,21 @@ import { ISnapshotComponent, ScoreRequest, ScoreResponse } from './types'
 export async function createSnapshotComponent(components: Pick<AppComponents, 'fetch' | 'config'>): Promise<ISnapshotComponent> {
   const { fetch, config } = components
   const SNAPSHOT_URL = await config.requireString('SNAPSHOT_URL')
+  const SNAPSHOT_NETWORK: ChainId.ETHEREUM_GOERLI | ChainId.ETHEREUM_MAINNET = await config.requireNumber('SNAPSHOT_NETWORK')
+  const SNAPSHOT_SPACE = await config.requireString('SNAPSHOT_SPACE')
+  if (SNAPSHOT_NETWORK !== ChainId.ETHEREUM_GOERLI && SNAPSHOT_NETWORK !== ChainId.ETHEREUM_MAINNET) {
+    throw new Error('The snapshot network id was not correctly set to either 1 or 5')
+  }
 
   async function getScore(address: string): Promise<number> {
     const data: ScoreRequest = {
       jsonrpc: '2.0',
       method: 'get_vp',
       params: {
-        network: '1',
+        network: SNAPSHOT_NETWORK.toString(),
         address: address.toLowerCase(),
-        strategies,
-        space: 'snapshot.dcl.eth',
+        strategies: strategies[SNAPSHOT_NETWORK],
+        space: SNAPSHOT_SPACE,
         delegation: false
       }
     }

--- a/src/ports/snapshot/component.ts
+++ b/src/ports/snapshot/component.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@dcl/schemas'
 import { isErrorWithMessage } from '../../logic/errors'
 import { AppComponents } from '../../types'
-import { strategies } from './constants'
+import { strategiesByChainId } from './constants'
 import { ScoreError } from './errors'
 import { ISnapshotComponent, ScoreRequest, ScoreResponse } from './types'
 
@@ -11,7 +11,7 @@ export async function createSnapshotComponent(components: Pick<AppComponents, 'f
   const SNAPSHOT_NETWORK: ChainId.ETHEREUM_GOERLI | ChainId.ETHEREUM_MAINNET = await config.requireNumber('SNAPSHOT_NETWORK')
   const SNAPSHOT_SPACE = await config.requireString('SNAPSHOT_SPACE')
   if (SNAPSHOT_NETWORK !== ChainId.ETHEREUM_GOERLI && SNAPSHOT_NETWORK !== ChainId.ETHEREUM_MAINNET) {
-    throw new Error('The snapshot network id was not correctly set to either 1 or 5')
+    throw new Error(`The snapshot network id was not correctly set to either ${ChainId.ETHEREUM_MAINNET} or ${ChainId.ETHEREUM_GOERLI}`)
   }
 
   async function getScore(address: string): Promise<number> {
@@ -21,7 +21,7 @@ export async function createSnapshotComponent(components: Pick<AppComponents, 'f
       params: {
         network: SNAPSHOT_NETWORK.toString(),
         address: address.toLowerCase(),
-        strategies: strategies[SNAPSHOT_NETWORK],
+        strategies: strategiesByChainId[SNAPSHOT_NETWORK],
         space: SNAPSHOT_SPACE,
         delegation: false
       }

--- a/src/ports/snapshot/constants.ts
+++ b/src/ports/snapshot/constants.ts
@@ -1,69 +1,130 @@
 import { ChainId } from '@dcl/schemas'
 
-export const strategies = [
-  {
-    name: 'multichain',
-    network: '1',
-    params: {
+export const strategies = {
+  [ChainId.ETHEREUM_MAINNET]: [
+    {
       name: 'multichain',
-      graphs: {
-        [ChainId.MATIC_MAINNET]: 'https://api.thegraph.com/subgraphs/name/decentraland/blocks-matic-mainnet'
-      },
-      symbol: 'MANA',
-      strategies: [
-        {
-          name: 'erc20-balance-of',
-          params: {
-            address: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
-            decimals: 18
-          },
-          network: '1'
+      network: '1',
+      params: {
+        name: 'multichain',
+        graphs: {
+          [ChainId.MATIC_MAINNET]: 'https://api.thegraph.com/subgraphs/name/decentraland/blocks-matic-mainnet'
         },
-        {
-          name: 'erc20-balance-of',
-          params: {
-            address: '0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4',
-            decimals: 18
+        symbol: 'MANA',
+        strategies: [
+          {
+            name: 'erc20-balance-of',
+            params: {
+              address: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+              decimals: 18
+            },
+            network: '1'
           },
-          network: '137'
-        }
-      ]
+          {
+            name: 'erc20-balance-of',
+            params: {
+              address: '0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4',
+              decimals: 18
+            },
+            network: '137'
+          }
+        ]
+      }
+    },
+    {
+      name: 'erc20-balance-of',
+      network: '1',
+      params: {
+        symbol: 'WMANA',
+        address: '0xfd09cf7cfffa9932e33668311c4777cb9db3c9be',
+        decimals: 18
+      }
+    },
+    {
+      name: 'erc721-with-multiplier',
+      network: '1',
+      params: {
+        symbol: 'LAND',
+        address: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
+        multiplier: 2000
+      }
+    },
+    {
+      name: 'decentraland-estate-size',
+      network: '1',
+      params: {
+        symbol: 'ESTATE',
+        address: '0x959e104e1a4db6317fa58f8295f586e1a978c297',
+        multiplier: 2000
+      }
+    },
+    {
+      name: 'erc721-with-multiplier',
+      network: '1',
+      params: {
+        symbol: 'NAMES',
+        address: '0x2a187453064356c898cae034eaed119e1663acb8',
+        multiplier: 100
+      }
     }
-  },
-  {
-    name: 'erc20-balance-of',
-    network: '1',
-    params: {
-      symbol: 'WMANA',
-      address: '0xfd09cf7cfffa9932e33668311c4777cb9db3c9be',
-      decimals: 18
+  ],
+  [ChainId.ETHEREUM_GOERLI]: [
+    {
+      name: 'multichain',
+      network: '5',
+      params: {
+        name: 'multichain',
+        graphs: {
+          [ChainId.ETHEREUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/decentraland/blocks-ethereum-goerli',
+          [ChainId.MATIC_MUMBAI]: 'https://api.thegraph.com/subgraphs/name/decentraland/blocks-matic-mumbai'
+        },
+        symbol: 'MANA',
+        strategies: [
+          {
+            name: 'erc20-balance-of',
+            params: {
+              address: '0xe7fDae84ACaba2A5Ba817B6E6D8A2d415DBFEdbe',
+              decimals: 18
+            },
+            network: '5'
+          },
+          {
+            name: 'erc20-balance-of',
+            params: {
+              address: '0x882Da5967c435eA5cC6b09150d55E8304B838f45',
+              decimals: 18
+            },
+            network: '80001'
+          }
+        ]
+      }
+    },
+    {
+      name: 'erc721-with-multiplier',
+      network: '5',
+      params: {
+        symbol: 'LAND',
+        address: '0x25b6B4bac4aDB582a0ABd475439dA6730777Fbf7',
+        multiplier: 2000
+      }
+    },
+    {
+      name: 'decentraland-estate-size',
+      network: '5',
+      params: {
+        symbol: 'ESTATE',
+        address: '0xC9A46712E6913c24d15b46fF12221a79c4e251DC',
+        multiplier: 2000
+      }
+    },
+    {
+      name: 'erc721-with-multiplier',
+      network: '5',
+      params: {
+        symbol: 'NAMES',
+        address: '0x6b8da2752827cf926215b43bb8E46Fd7b9dDac35',
+        multiplier: 100
+      }
     }
-  },
-  {
-    name: 'erc721-with-multiplier',
-    network: '1',
-    params: {
-      symbol: 'LAND',
-      address: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
-      multiplier: 2000
-    }
-  },
-  {
-    name: 'decentraland-estate-size',
-    network: '1',
-    params: {
-      symbol: 'ESTATE',
-      address: '0x959e104e1a4db6317fa58f8295f586e1a978c297',
-      multiplier: 2000
-    }
-  },
-  {
-    name: 'erc721-with-multiplier',
-    network: '1',
-    params: {
-      symbol: 'NAMES',
-      address: '0x2a187453064356c898cae034eaed119e1663acb8',
-      multiplier: 100
-    }
-  }
-]
+  ]
+}

--- a/src/ports/snapshot/constants.ts
+++ b/src/ports/snapshot/constants.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@dcl/schemas'
 
-export const strategies = {
+export const strategiesByChainId = {
   [ChainId.ETHEREUM_MAINNET]: [
     {
       name: 'multichain',

--- a/src/ports/snapshot/types.ts
+++ b/src/ports/snapshot/types.ts
@@ -3,7 +3,7 @@ export type ScoreRequest = {
   method: 'get_vp'
   params: {
     address: string
-    network: '1'
+    network: string
     strategies: unknown[]
     snapshot?: number
     space: string

--- a/test/components.ts
+++ b/test/components.ts
@@ -1,6 +1,6 @@
 // This file is the "test-environment" analogous for src/components.ts
 // Here we define the test components to be used in the testing environment
-
+import path from 'node:path'
 import { createDotEnvConfigComponent } from '@well-known-components/env-config-provider'
 import { instrumentHttpServerWithRequestLogger, Verbosity } from '@well-known-components/http-requests-logger-component'
 import { createServerComponent } from '@well-known-components/http-server'
@@ -41,22 +41,10 @@ async function initComponents(): Promise<TestComponents> {
   const currentPort = getFreePort()
   // default config from process.env + .env file
   const defaultConfig = {
-    SNAPSHOT_URL: 'https://snapshot-url.com',
-    SNAPSHOT_NETWORK: '1',
-    SNAPSHOT_SPACE: 'snapshot.dcl.eth',
-    HTTP_SERVER_PORT: (currentPort + 1).toString(),
-    HTTP_SERVER_HOST: 'localhost',
-    COLLECTIONS_SUBGRAPH_URL: 'https://some-url.com',
-    SUBGRAPH_COMPONENT_RETRIES: '0',
-    PG_COMPONENT_PSQL_DATABASE: 'marketplace',
-    PG_COMPONENT_PSQL_SCHEMA: 'favorites',
-    PG_COMPONENT_PSQL_PORT: '5432',
-    PG_COMPONENT_PSQL_HOST: 'localhost',
-    PG_COMPONENT_PSQL_USER: 'username',
-    PG_COMPONENT_PSQL_PASSWORD: 'password'
+    HTTP_SERVER_PORT: (currentPort + 1).toString()
   }
 
-  const config = await createDotEnvConfigComponent({}, defaultConfig)
+  const config = await createDotEnvConfigComponent({ path: path.resolve(__dirname, '../.env.default') }, defaultConfig)
   const metrics = await createMetricsComponent(metricDeclarations, { config })
   const tracer = createTracerComponent()
   const logs = await createLogComponent({ metrics, tracer })

--- a/test/components.ts
+++ b/test/components.ts
@@ -42,6 +42,8 @@ async function initComponents(): Promise<TestComponents> {
   // default config from process.env + .env file
   const defaultConfig = {
     SNAPSHOT_URL: 'https://snapshot-url.com',
+    SNAPSHOT_NETWORK: '1',
+    SNAPSHOT_SPACE: 'snapshot.dcl.eth',
     HTTP_SERVER_PORT: (currentPort + 1).toString(),
     HTTP_SERVER_HOST: 'localhost',
     COLLECTIONS_SUBGRAPH_URL: 'https://some-url.com',

--- a/test/unit/snapshot-component.spec.ts
+++ b/test/unit/snapshot-component.spec.ts
@@ -7,29 +7,36 @@ let snapshotComponent: ISnapshotComponent
 let fetchComponent: IFetchComponent
 let configComponent: IConfigComponent
 let mockedRequireString: jest.Mock
+let mockedRequireNumber: jest.Mock
 let mockedFetch: jest.Mock
 
-beforeEach(async () => {
+beforeEach(() => {
   mockedRequireString = jest.fn()
+  mockedRequireNumber = jest.fn()
   mockedFetch = jest.fn()
   fetchComponent = { fetch: mockedFetch }
   configComponent = {
     getString: jest.fn(),
     getNumber: jest.fn(),
     requireString: mockedRequireString,
-    requireNumber: jest.fn()
+    requireNumber: mockedRequireNumber
   }
-  snapshotComponent = await createSnapshotComponent({
-    config: configComponent,
-    fetch: fetchComponent
-  })
 })
 
 describe("when getting the user's score", () => {
   const address = '0xa3D963609EEaA7aA796c81E8c6f945c601f9BEc7'
   const snapshotURL = 'http://snapshot-url.com'
-  beforeEach(() => {
+  const snapshotSpace = 'snapshot.dcl.eth'
+  const snapshotNetwork = 1
+
+  beforeEach(async () => {
     mockedRequireString.mockResolvedValueOnce(snapshotURL)
+    mockedRequireNumber.mockResolvedValueOnce(snapshotNetwork)
+    mockedRequireString.mockResolvedValueOnce(snapshotSpace)
+    snapshotComponent = await createSnapshotComponent({
+      config: configComponent,
+      fetch: fetchComponent
+    })
   })
 
   describe('and the request to snapshot fails', () => {


### PR DESCRIPTION
This PR changes the way we're requesting the snapshot API so we can get the VP of a user in Goerli and Mainnet.
This is done by adding two new parameters, `SNAPSHOT_NETWORK` and `SNAPSHOT_SPACE`, which can be configured to get the VP on either networks.

Closes #68 