### PR TITLE
chore: Use build and publish release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Build and publish
+on:
+  release:
+    types:
+      - created
+jobs:
+  build:
+    name: 'Build & publish: {{github.ref}}'
+    uses: decentraland/actions/.github/workflows/build-quay-main.yml@main
+    with:
+      service-name: marketplace-favorites-server
+      docker-tag: '{{ github.ref }}'
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
This PR adds the builds and publish job which deploys docker images with tags that can be later used in the deployment process.