### PR TITLE
feat: Make it possible to query picks of a list according to the ACL

### DIFF
--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -31,8 +31,9 @@ export function createListsComponent(
   async function getPicksByListId(listId: string, params: GetAuthenticatedAndPaginatedParameters): Promise<DBGetFilteredPicksWithCount[]> {
     const { userAddress, limit, offset } = params
     const result = await pg.query<DBGetFilteredPicksWithCount>(SQL`
-        SELECT p.*, COUNT(*) OVER() as picks_count FROM favorites.picks p
-        WHERE list_id = ${listId} AND user_address = ${userAddress}
+        SELECT DISTINCT(p.item_id), p.*, COUNT(*) OVER() as picks_count FROM favorites.picks p
+        LEFT JOIN favorites.acl ON p.list_id = favorites.acl.list_id
+        WHERE p.list_id = ${listId} AND (p.user_address = ${userAddress} OR favorites.acl.grantee = ${userAddress} OR favorites.acl.grantee = '*')
         ORDER BY created_at DESC
         LIMIT ${limit} OFFSET ${offset}
     `)

--- a/src/ports/lists/component.ts
+++ b/src/ports/lists/component.ts
@@ -22,6 +22,8 @@ import {
   ListSortDirection
 } from './types'
 
+const GRANTED_TO_ALL = '*'
+
 export function createListsComponent(
   components: Pick<AppComponents, 'pg' | 'collectionsSubgraph' | 'snapshot' | 'logs'>
 ): IListsComponents {
@@ -33,7 +35,7 @@ export function createListsComponent(
     const result = await pg.query<DBGetFilteredPicksWithCount>(SQL`
         SELECT DISTINCT(p.item_id), p.*, COUNT(*) OVER() as picks_count FROM favorites.picks p
         LEFT JOIN favorites.acl ON p.list_id = favorites.acl.list_id
-        WHERE p.list_id = ${listId} AND (p.user_address = ${userAddress} OR favorites.acl.grantee = ${userAddress} OR favorites.acl.grantee = '*')
+        WHERE p.list_id = ${listId} AND (p.user_address = ${userAddress} OR favorites.acl.grantee = ${userAddress} OR favorites.acl.grantee = ${GRANTED_TO_ALL})
         ORDER BY created_at DESC
         LIMIT ${limit} OFFSET ${offset}
     `)

--- a/test/unit/lists-component.spec.ts
+++ b/test/unit/lists-component.spec.ts
@@ -101,18 +101,18 @@ describe('when getting picks from a list by list id', () => {
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
           strings: expect.arrayContaining([
-            expect.stringContaining('WHERE p.list_id = '),
-            expect.stringContaining(' AND (p.user_address = '),
-            expect.stringContaining(' OR favorites.acl.grantee = '),
-            expect.stringContaining(" OR favorites.acl.grantee = '*'")
+            expect.stringContaining('WHERE p.list_id ='),
+            expect.stringContaining('AND (p.user_address ='),
+            expect.stringContaining('OR favorites.acl.grantee ='),
+            expect.stringContaining('OR favorites.acl.grantee =')
           ]),
-          values: expect.arrayContaining(['list-id', '0xuseraddress', '0xuseraddress'])
+          values: expect.arrayContaining(['list-id', '0xuseraddress', '0xuseraddress', '*'])
         })
       )
 
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
-          strings: expect.arrayContaining([expect.stringContaining('LIMIT '), expect.stringContaining(' OFFSET ')]),
+          strings: expect.arrayContaining([expect.stringContaining('LIMIT'), expect.stringContaining('OFFSET')]),
           values: expect.arrayContaining([10, 0])
         })
       )

--- a/test/unit/lists-component.spec.ts
+++ b/test/unit/lists-component.spec.ts
@@ -97,16 +97,22 @@ describe('when getting picks from a list by list id', () => {
           userAddress: '0xuseraddress'
         })
       ).resolves.toEqual(dbGetPicksByListId)
+
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
-          text: expect.stringContaining('WHERE list_id = $1 AND user_address = $2'),
-          values: expect.arrayContaining(['list-id', '0xuseraddress'])
+          strings: expect.arrayContaining([
+            expect.stringContaining('WHERE p.list_id = '),
+            expect.stringContaining(' AND (p.user_address = '),
+            expect.stringContaining(' OR favorites.acl.grantee = '),
+            expect.stringContaining(" OR favorites.acl.grantee = '*'")
+          ]),
+          values: expect.arrayContaining(['list-id', '0xuseraddress', '0xuseraddress'])
         })
       )
 
       expect(dbQueryMock).toBeCalledWith(
         expect.objectContaining({
-          text: expect.stringContaining('LIMIT $3 OFFSET $4'),
+          strings: expect.arrayContaining([expect.stringContaining('LIMIT '), expect.stringContaining(' OFFSET ')]),
           values: expect.arrayContaining([10, 0])
         })
       )


### PR DESCRIPTION
This PR changes the `/v1/lists/:id/picks` endpoint so any users that have a permission to view or edit lists can view them.

Closes #103